### PR TITLE
Make sniffybara the `default_driver` instead of the `current_driver`

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,7 +27,7 @@ require "rspec/rails"
 # ActiveRecord::Migration.maintain_test_schema!
 
 require "capybara"
-Capybara.current_driver = :sniffybara
+Capybara.default_driver = :sniffybara
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
will make sniffybara the driver for *all* the tests, not just the first one.
:doh: