### PR TITLE
Remove ruby version from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-rvm:
-  - 2.3.0
 
 branches:
     only:


### PR DESCRIPTION
Because Roadrunner-Rails has a .ruby-version file, it doesn't need to include the ruby version in Travis. This will make it easier to upgrade the Ruby version in the future. 

https://docs.travis-ci.com/user/languages/ruby#Using-.ruby-version