### PR TITLE
Expire all cookies after 2 weeks

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_roadrunner-rails_session'
+Rails.application.config.session_store :cookie_store, key: '_roadrunner-rails_session', expire_after: 2.weeks


### PR DESCRIPTION
This means our cookies will expire 2 weeks from the last request (not
from the initial request)